### PR TITLE
The .art* format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-*.artm
-*.artmb
+*.art[ycr]
+*.art[ycr]b
 
 # Created by https://www.gitignore.io/api/macos,linux,windows,intellij+iml,visualstudio,visualstudiocode,rust
 # Edit at https://www.gitignore.io/?templates=macos,linux,windows,intellij+iml,visualstudio,visualstudiocode,rust

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-*.am[ycr]
-*.am[ycr]b
+*.artm
+*.artmb
 
 # Created by https://www.gitignore.io/api/macos,linux,windows,intellij+iml,visualstudio,visualstudiocode,rust
 # Edit at https://www.gitignore.io/?templates=macos,linux,windows,intellij+iml,visualstudio,visualstudiocode,rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
 name = "artm"
 version = "0.2.15"
 dependencies = [
- "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -36,22 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "blake2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -90,34 +73,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "digest"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "generic-array"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "itoa"
@@ -149,11 +107,6 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -323,13 +276,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.7.0"
+name = "sha1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "subtle"
-version = "1.0.0"
+name = "strsim"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -382,11 +335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -449,21 +398,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
-"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -483,14 +426,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
 name = "artm"
 version = "0.2.15"
 dependencies = [
+ "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -35,6 +36,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "blake2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -73,9 +90,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "digest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
@@ -107,6 +149,11 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -281,6 +328,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "subtle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.15.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +380,11 @@ dependencies = [
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
@@ -392,15 +449,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
+"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -421,11 +484,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ version = "0.2.15"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -123,6 +124,18 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -409,6 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,15 +7,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "artm"
 version = "0.3.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -35,9 +54,40 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "backtrace"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "block-buffer"
@@ -66,6 +116,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byteorder"
 version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -104,11 +164,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -146,6 +241,19 @@ dependencies = [
 [[package]]
 name = "libc"
 version = "0.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -312,8 +420,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ryu"
 version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -356,6 +485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +507,27 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -474,23 +634,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f106c02a3604afcdc0df5d36cc47b44b55917dbaf3d808f71c163a0ddba64637"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)" = "30f813bf45048a18eda9190fd3c6b78644146056740c43172a5a3699118588fd"
+"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
@@ -510,13 +683,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
+"checksum simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e95345f185d5adeb8ec93459d2dc99654e294cc6ccf5b75414d8ea262de9a13"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -36,6 +37,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "block-buffer"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -74,9 +104,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
@@ -108,6 +159,11 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -294,6 +350,17 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "sha2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +413,11 @@ dependencies = [
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
@@ -411,15 +483,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
+"checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
+"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -441,12 +521,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
 
 [[package]]
 name = "artm"
-version = "0.2.15"
+version = "0.3.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -345,11 +345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "sha2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,7 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -520,7 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
-"checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ A request, commmission, and YCH art manager.
 
 [dependencies]
 serde_json = "1.0"
+blake2 = "0.8"
 
 [dependencies.clap]
 version = "2.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ A request, commmission, and YCH art manager.
 [dependencies]
 serde_json = "1.0"
 rand = "0.4"
+sha2 = "0.8.0"
 
 [dependencies.clap]
 version = "2.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ A request, commmission, and YCH art manager.
 """
 
 [dependencies]
+log = "0.4"
+simplelog = "^0.5.0"
 serde_json = "1.0"
 rand = "0.4"
 sha2 = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ A request, commmission, and YCH art manager.
 
 [dependencies]
 serde_json = "1.0"
+rand = "0.4"
 
 [dependencies.clap]
 version = "2.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artm"
-version = "0.2.15"
+version = "0.3.0"
 authors = ["Anthony Wilcox"]
 repository = "https://github.com/antonwilc0x/artm"
 license = "GNU GPL v3"
@@ -20,7 +20,7 @@ features = [ "yaml", "wrap_help" ]
 
 [dependencies.uuid]
 version = "0.7"
-features = ["serde", "v4", "v5"]
+features = ["serde", "v4"]
 
 [dependencies.serde]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ A request, commmission, and YCH art manager.
 
 [dependencies]
 serde_json = "1.0"
-blake2 = "0.8"
 
 [dependencies.clap]
 version = "2.32"
@@ -19,7 +18,7 @@ features = [ "yaml", "wrap_help" ]
 
 [dependencies.uuid]
 version = "0.7"
-features = ["serde", "v4"]
+features = ["serde", "v4", "v5"]
 
 [dependencies.serde]
 version = "1.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,94 @@
+# Change log
+
+## 0.3.0
+
+- New ``.artm`` format that unfies the former into a single one with many options.
+- YCH, Commission, and Request subcommands, flags or values are no longer required! Finally. The program assumes what you want based on the options selected - as it should be, imo. For example, if ``--payment`` and ``--slot`` isn't used then it assumes you're referring to a Request. This doesn't effect Raffle system.
+- ``--art`` was renamed to ``--name`` and has been made global for use with the ``raffe`` subcommand. However, ``--cust`` renames the same.
+- Secure ID and Raffle methods now generate their own respective IDs based on Sha256.
+
+
+### .artm format
+
+The most notable improvement that compliments the above changes is the merger of ``.arty``, ``.artc`` and ``.artr`` into the singular ``.artm`` format. The reason why this wasn't done earlier is because I initially wrote this with not much understanding of [Clap](https://github.com/clap-rs/clap)'s potential and that all three former formats were different implementations all doing the same thing.
+
+```json
+{
+  "id": "",
+  "version": "",
+  "name": "",
+  "price": "",
+  "ticket": "",
+  "slot": "",
+  "description": "",
+  "reference": "",
+  "customer": {
+    "name": "",
+    "contact": "",
+    "payment": ""
+  }
+}
+```
+And so the previous YCH example found in the usage page becomes...
+```json
+{
+  "id": "c152c08a-1250-45c1-a51d-a38354804933",
+  "date": "2019-04-05T13:53:43.670815600-04:00",
+  "version": "0.1",
+  "name": "Synthesize",
+  "category": "YCH",
+  "slot": "4",
+  "price": "$25",
+  "reference": "https://www.furaffinity.net/view/20700210/",
+  "customer": {
+    "name": "Bessie Hettinger",
+    "contact": "Jack.Torphy75",
+    "payment": "31VLNZXfcpoA68wPRuWSdrmT3jv5k"
+  }
+}
+```
+We're able to create as many variations of this format as we want using the [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern), this method is common in a lot of Rust libraries and frameworks. This takes care of a lot of the heavy lifting that had been done previously.
+
+```rust
+// Example
+Art::new()
+        .price(price)
+        .name(name)
+        .category(Category::YCH)
+        .slot(slot)
+        .reference(reference)
+        .customer(Customer::new()
+            .name(cust_name)
+            .payment(pay)
+            .contact(cont))
+        .secure_id()
+        .write_file(debug);
+```
+
+### Secure Ids
+
+Up until now, Art Manager's Ids have been random UUIDs. 0.3 introduces secure Ids that use Sha256 for use as a checksum. These come in two variations, both based on *local time*: normal and raffle.
+
+- Normal: ``artm:[year][month][day][hour][minute][name]``
+- Raffle: ``artm:[year][month][day][hour][minute][name][ticket][slot]``
+
+## 0.2.10
+
+- Request & Commissions are now flags since they share a lot of the same data. YCH is now a subcommand that now carries the Raffle subcommand. Due to this new arrangement, all current optional arguments are now global including the one in the YCH subcommand, so it can be accessed by the Raffle.
+
+## 0.2.5
+
+- Request feature now be accessed.
+- Request, Commission and YCH flags now conflict with each other.
+- Argument changes: "order" is now "art", as in the art's name, "pay" is now payment", and "cost" is now "price."
+- New arguments include "reference" and "description", these names were shortned to "ref" and "desc", respectfully. Reference is used for YCHs while description is used for Commissions and Requests.
+- Added the raffle subcommand. It'll crash if you use all but --help.
+
+## 0.2.0
+
+- ``--debug`` flag prints the output to the screen as oppose to a file.
+- Reverted back to using subcommands again now that everything was moved to config file.
+- Client is now customer.
+- Username is now contact.
+- Customer, contact, payment and tickets options are now abbreviated.
+- Debug flag is now global.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,15 +2,16 @@
 
 ## 0.3.0
 
-- New ``.artm`` format that unfies the former into a single one with many options.
-- YCH, Commission, and Request subcommands, flags or values are no longer required! Finally. The program assumes what you want based on the options selected - as it should be, imo. For example, if ``--payment`` and ``--slot`` isn't used then it assumes you're referring to a Request. This doesn't effect Raffle system.
+- ``.art[ycr]`` replaces the former ``.artm[ycr]`` format.
+- Submissions and file creations are now logged.
+- YCH, Commission, and Request subcommands, flags or values are no longer required! Finally. The program assumes what you want based on the options selected - as it should be, imo. For example, if ``--payment`` and ``--slot`` isn't used then it assumes you're referring to a Request. Raffle remains it's own subcommand with different arguments.
 - ``--art`` was renamed to ``--name`` and has been made global for use with the ``raffe`` subcommand. However, ``--cust`` renames the same.
 - Secure ID and Raffle methods now generate their own respective IDs based on Sha256.
 
 
-### .artm format
+### .artm* is now .art*
 
-The most notable improvement that compliments the above changes is the merger of ``.arty``, ``.artc`` and ``.artr`` into the singular ``.artm`` format. The reason why this wasn't done earlier is because I initially wrote this with not much understanding of [Clap](https://github.com/clap-rs/clap)'s potential and that all three former formats were different implementations all doing the same thing.
+The current ``.artm[ycr]`` formats has been redone as ``.art[ycr]``. The older format were based on three independent implementations that all did very similar things but lacked room for change. This worked as a proof-as-concept but left no room to grow. This new format merges all three by making every field optional and won't show up, if left empty, with the exception of name, version, date and Id.
 
 ```json
 {
@@ -47,11 +48,11 @@ And so the previous YCH example found in the usage page becomes...
   }
 }
 ```
-We're able to create as many variations of this format as we want using the [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern), this method is common in a lot of Rust libraries and frameworks. This takes care of a lot of the heavy lifting that had been done previously.
+We're able to create as many variations of this format as we want using the [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern), this method is common in a lot of Rust libraries and frameworks. This takes care of a lot of the heavy lifting and allows for any number of combination to exist.
 
 ```rust
 // Example
-Art::new()
+    if let Err(err) = Art::new()
         .price(price)
         .name(name)
         .category(Category::YCH)
@@ -62,7 +63,11 @@ Art::new()
             .payment(pay)
             .contact(cont))
         .secure_id()
-        .write_file(debug);
+        .debug(debug)
+        .write_file() {
+        println!("{}: {}", ERROR_MSG, err);
+        process::exit(EXIT_CODE);
+    }
 ```
 
 ### Secure Ids

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A command line interface for storing art request, commission, and YCH information. The application is a work in progress but contribution is welcomed.
 
-## Status
-
 | Branch | Status |
 | :---: | :---: |
 | Master | [![Build Status](https://travis-ci.com/antonwilc0x/artm.svg?branch=master)](https://travis-ci.com/antonwilc0x/artm) |

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,6 @@
 - [ ] Database
 - [ ] YCH Raffle
 - [x] Write to file
-    - [x] YCH: ``[art] - [slot] - [customer].amy``
-    - [x] Commission/Requests: ``[art] - [customer].am[cr]``
 - [x] Basic Submission Info
     - [x] YCH
     - [x] Commission

--- a/Usage.md
+++ b/Usage.md
@@ -7,7 +7,7 @@ There is no limitation on what the username and payment field has to be. As long
 ## Requests & Commissions
 
 ### Requests
-``artm --comm --art <art> --cont <contact> --cust <customer> --desc <description>``
+``artm --req --art <art> --cont <contact> --cust <customer> --desc <description>``
 
 Example: ``artm --req --cust "Lupe Jacobson" --cont "Kasey.Goyette18" --art "virtual" --desc "Lorem ipsum [...]"``
 
@@ -16,7 +16,7 @@ This will produce ``virtual - lupe jacobson.amr`` with the following contents:
 {
   "id": "63d4749e-3814-4861-915e-8fb01df14381",
   "date": "2019-04-02T03:54:25.297501-04:00",
-  "client": "Lupe Jacobson",
+  "customer": "Lupe Jacobson",
   "contact": "Kasey.Goyette18",
   "art": "virtual",
   "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vitae scelerisque lectus. Proin id felis."
@@ -34,7 +34,7 @@ This will produce ``tonga - alberta mann.amc`` with the following contents:
   "id": "55b63ab9-397c-481d-92d3-bf7978d40d69",
   "date": "2019-04-02T02:09:10.351457-04:00",
   "art": "Tonga",
-  "client": "Alberta Mann",
+  "customer": "Alberta Mann",
   "contact": "Chanel_McKenzie7",
   "price": "$43",
   "payment": "5458-2118-9194-8514",
@@ -43,16 +43,19 @@ This will produce ``tonga - alberta mann.amc`` with the following contents:
 ```
 
 ## YCH
+
+YCH shares the same options as commissions but ``--desc`` is removed in favor of ``--slot`` and ``--ref``. It has been extended into it's own subcommand because it has more in common with [eBay-style](https://en.wikipedia.org/wiki/English_auction) auctions and can extended, if needed.
+
 ``artm ych --art <art> --cont <contact> --cust <customer> --pmt <payment> --price <price> --ref <reference>``
 
-Example: ``artm ych --client "Bessie Hettinger" --contact "Jack.Torphy75" --art "Synthesize" --slot 4 --price "$25" --payment "31VLNZXfcpoA68wPRuWSdrmT3jv5k" --ref "https://www.furaffinity.net/view/20700210/"``
+Example: ``artm ych --cust "Bessie Hettinger" --cont "Jack.Torphy75" --art "Synthesize" --slot 4 --price "$25" --payment "31VLNZXfcpoA68wPRuWSdrmT3jv5k" --ref "https://www.furaffinity.net/view/20700210/"``
 
 This will produce ``synthesize - 4 - bessie hettinger.amy`` with the following contents:
 ```json
 {
   "id": "16b5cd5a-9372-414c-85fd-952c14dd9205",
   "date": "2019-04-02T02:08:15.831915500-04:00",
-  "client": "Bessie Hettinger",
+  "customer": "Bessie Hettinger",
   "reference": "https://www.furaffinity.net/view/20700210/",
   "art": "Synthesize",
   "slot": "4",
@@ -64,4 +67,4 @@ This will produce ``synthesize - 4 - bessie hettinger.amy`` with the following c
 
 ### Raffle
 
-TBA
+TBA. See issue [#1](https://github.com/antonwilc0x/artm/issues/1).

--- a/Usage.md
+++ b/Usage.md
@@ -4,64 +4,68 @@ It's recommended to use quotation marks for field values, unless it involves num
 
 There is no limitation on what the username and payment field has to be. As long as both provide a legit means of contact (email, FA, DA, ect..) and payment (paypal, crypto, bank, ect..), respectfully, it does not matter.
 
-## Requests & Commissions
+## Requests
+``artm --art <art> --cont <contact> --name <name> --cust <customer> --desc <description>``
 
-### Requests
-``artm --req --art <art> --cont <contact> --cust <customer> --desc <description>``
+Example: ``artm --cust "Lupe Jacobson" --cont "Kasey.Goyette18" --name "virtual" --desc "Lorem ipsum [...]"``
 
-Example: ``artm --req --cust "Lupe Jacobson" --cont "Kasey.Goyette18" --art "virtual" --desc "Lorem ipsum [...]"``
-
-This will produce ``virtual - lupe jacobson.amr`` with the following contents:
 ```json
 {
-  "id": "63d4749e-3814-4861-915e-8fb01df14381",
-  "date": "2019-04-02T03:54:25.297501-04:00",
-  "customer": "Lupe Jacobson",
-  "contact": "Kasey.Goyette18",
-  "art": "virtual",
-  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vitae scelerisque lectus. Proin id felis."
+  "id": "36154b77e269bce9fca4c841a9ff7627dae4ad954fc8b9f8c3e28f063f2cfd6a",
+  "date": "2019-04-06T15:46:46.395352700-04:00",
+  "version": "0.1",
+  "name": "virtual",
+  "category": "Request",
+  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vitae scelerisque lectus. Proin id felis.",
+  "customer": {
+    "name": "Lupe Jacobson",
+    "contact": "Kasey.Goyette18"
+  }
 }
 ```
 
 ### Commissions
-``artm --comm --cont <contact> --cust <customer> --desc <description> --pmt <payment> --price <price>``
+``artm --cont <contact> --name <name> --cust <customer> --desc <description> --pmt <payment> --price <price>``
 
-Example: ``artm comm --cust "Alberta Mann" --cont "Chanel_McKenzie7" --art "Tonga" --price "$43" --pmt "5458-2118-9194-8514" --desc "Lorem ipsum [...]"``
+Example: ``artm --cust "Alberta Mann" --cont "Chanel_McKenzie7" --name "Tonga" --price "$43" --pmt "5458-2118-9194-8514" --desc "Lorem ipsum [...]"``
 
-This will produce ``tonga - alberta mann.amc`` with the following contents:
 ```json
 {
-  "id": "55b63ab9-397c-481d-92d3-bf7978d40d69",
-  "date": "2019-04-02T02:09:10.351457-04:00",
-  "art": "Tonga",
-  "customer": "Alberta Mann",
-  "contact": "Chanel_McKenzie7",
+  "id": "6887f01a6c63c8130ea75a49d0ddff5b4cc5ad899ad127b396a09ba5559b63b1",
+  "date": "2019-04-06T15:51:33.941149800-04:00",
+  "version": "0.1",
+  "name": "Tonga",
+  "category": "Commission",
   "price": "$43",
-  "payment": "5458-2118-9194-8514",
-  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ut pretium enim. Sed a neque."
+  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ut pretium enim. Sed a neque.",
+  "customer": {
+    "name": "Alberta Mann",
+    "contact": "Chanel_McKenzie7",
+    "payment": "5458-2118-9194-8514"
+  }
 }
 ```
 
 ## YCH
+``artm --name <name> --cont <contact> --slot <slot> --cust <customer> --pmt <payment> --price <price> --ref <reference>``
 
-YCH shares the same options as commissions but ``--desc`` is removed in favor of ``--slot`` and ``--ref``. It has been extended into it's own subcommand because it has more in common with [eBay-style](https://en.wikipedia.org/wiki/English_auction) auctions and can extended, if needed.
+Example: ``artm --cust "Bessie Hettinger" --cont "Jack.Torphy75" --name "Synthesize" --slot 4 --price "$25" --payment "31VLNZXfcpoA68wPRuWSdrmT3jv5k" --ref "https://www.furaffinity.net/view/20700210/"``
 
-``artm ych --art <art> --cont <contact> --cust <customer> --pmt <payment> --price <price> --ref <reference>``
-
-Example: ``artm ych --cust "Bessie Hettinger" --cont "Jack.Torphy75" --art "Synthesize" --slot 4 --price "$25" --payment "31VLNZXfcpoA68wPRuWSdrmT3jv5k" --ref "https://www.furaffinity.net/view/20700210/"``
-
-This will produce ``synthesize - 4 - bessie hettinger.amy`` with the following contents:
 ```json
 {
-  "id": "16b5cd5a-9372-414c-85fd-952c14dd9205",
-  "date": "2019-04-02T02:08:15.831915500-04:00",
-  "customer": "Bessie Hettinger",
-  "reference": "https://www.furaffinity.net/view/20700210/",
-  "art": "Synthesize",
+  "id": "fe8cf9771a9633e754cbafd0081e58bd3dcba286bdcc8012fb47c6eb0c3a6d33",
+  "date": "2019-04-06T15:52:13.596792600-04:00",
+  "version": "0.1",
+  "name": "Synthesize",
+  "category": "YCH",
   "slot": "4",
-  "contact": "Jack.Torphy75",
   "price": "$25",
-  "payment": "31VLNZXfcpoA68wPRuWSdrmT3jv5k"
+  "reference": "https://www.furaffinity.net/view/20700210/",
+  "customer": {
+    "name": "Bessie Hettinger",
+    "contact": "Jack.Torphy75",
+    "payment": "31VLNZXfcpoA68wPRuWSdrmT3jv5k"
+  }
 }
 ```
 

--- a/src/art.rs
+++ b/src/art.rs
@@ -5,7 +5,7 @@ use log::{info};
 use sha2::{Sha256, Digest};
 use chrono::prelude::*;
 use uuid::{Uuid};
-use cmds::*;
+use crate::cmds::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
 use std::fs::OpenOptions;

--- a/src/art.rs
+++ b/src/art.rs
@@ -92,7 +92,7 @@ impl Art {
 
     pub fn new() -> Art {
         Art {
-            id: "".to_string(),
+            id: Uuid::new_v4().to_string(),
             date: Local::now(),
             version: "0.1".to_string(),
             name: "".to_string(),
@@ -177,38 +177,42 @@ impl Art {
     pub fn write_file(&self, debug: bool) -> Result<()> {
         let json_string = serde_json::to_string_pretty(self)?;
 
-        match debug {
-            true => println!("{}", json_string),
-            false => {
-                let cat = &self.category;
-                let ticket = self.ticket.to_owned().unwrap();
-                let slot = self.slot.to_owned().unwrap();
-                let name = self.name.to_owned();
-                let mut file_name = String::new();
+        if debug == true {
+            println!("{}", json_string);
+        }
+        else
+        {
+            let cat = &self.category;
+            let mut slot = String::new();
+            let name = self.name.to_owned();
+            let mut file_name = String::new();
 
-                match cat {
-                    Some(Category::YCH) => {
-                        file_name = format!("{} - {}.{}",
-                                                name, slot, ARTM_EXT);
-                    }
-                    Some(Category::Raffle) => {
-                        file_name = format!("{} - {} {}.{}",
-                                            name, ticket, slot, ARTM_EXT);
-                    }
-                    _ => {
-                        file_name = format!("{}.{}",
-                                            name, ARTM_EXT);
-                    }
+            match cat {
+                Some(Category::YCH) => {
+                    slot = self.slot.to_owned().unwrap();
+                    file_name = format!("{} - {}.{}",
+                                        name, slot, ARTM_EXT);
                 }
+                Some(Category::Raffle) => {
+                    slot = self.slot.to_owned().unwrap();
+                    let ticket = self.ticket.to_owned().unwrap();
 
-                let mut file = OpenOptions::new().write(true)
-                    .create_new(true)
-                    .open(file_name)
-                    .expect("Could not open file.");
-
-                if let Err(err) = writeln!(file, "{}", format!("{}", json_string)) {
-                    eprintln!("Could not write to file. {}", err);
+                    file_name = format!("{} - {} {}.{}",
+                                        name, ticket, slot, ARTM_EXT);
                 }
+                _ => {
+                    file_name = format!("{}.{}",
+                                        name, ARTM_EXT);
+                }
+            }
+
+            let mut file = OpenOptions::new().write(true)
+                .create_new(true)
+                .open(file_name)
+                .expect("Could not open file.");
+
+            if let Err(err) = writeln!(file, "{}", format!("{}", json_string)) {
+                eprintln!("Could not write to file. {}", err);
             }
         }
 

--- a/src/artm.yml
+++ b/src/artm.yml
@@ -1,20 +1,17 @@
 name: Art Manager
 args:
-  - commission:
-      long: comm
-  - request:
-      aliases: [req]
-      long: request
   - database:
       long: db
+  - category:
+      long: cat
+      takes_value: true
+      possible_values: [ych, comm, req]
   - debug:
       help: Outputs debug information.
-      global: true
       aliases: [dbg]
       long: debug
       short: d
   - customer:
-      global: true
       long: cust
       takes_value: true
   - art:
@@ -30,41 +27,16 @@ args:
       long: contact
       takes_value: true
   - price:
-      global: true
       long: price
       aliases: [cost]
       takes_value: true
-  - file:
-    global: true
-    long: file
-    takes_value: true
   - payment:
-      global: true
       long: payment
       aliases: [pmt]
       takes_value: true
-
-subcommands:
-  - ych:
-      subcommands:
-        - raffle:
-            aliases: [raf]
-            about: A varient of YCH.
-            args:
-            - slots:
-                long: slots
-                takes_value: true
-            - tickets:
-                aliases: [tkts]
-                long: tickets
-                takes_value: true
-      about: Your Character Here.
-      args:
-        - slot:
-            long: slot
-            takes_value: true
-            required: true
-        - reference:
-            long: ref
-            takes_value: true
-            required: true
+  - slot:
+      long: slot
+      takes_value: true
+  - reference:
+      long: ref
+      takes_value: true

--- a/src/artm.yml
+++ b/src/artm.yml
@@ -1,12 +1,5 @@
 name: Art Manager
 args:
-  - database:
-      long: db
-  - category:
-      long: cat
-      takes_value: true
-      possible_values: [ych, comm, req]
-      global: true
   - debug:
       help: Outputs debug information.
       aliases: [dbg]
@@ -16,8 +9,12 @@ args:
   - customer:
       long: cust
       takes_value: true
-  - art:
-      long: art
+  - name:
+      long: name
+      takes_value: true
+      global: true
+  - reference:
+      long: ref
       takes_value: true
   - description:
       long: desc
@@ -37,13 +34,10 @@ args:
   - slot:
       long: slot
       takes_value: true
-  - reference:
-      long: ref
-      takes_value: true
 
 subcommands:
   - raffle:
-      about: YCH raffle
+      about: YCH raffle. Coming soon.
       args:
         - tickets:
             aliases: [tkts]

--- a/src/artm.yml
+++ b/src/artm.yml
@@ -5,6 +5,8 @@ args:
   - request:
       aliases: [req]
       long: request
+  - database:
+      long: db
   - debug:
       help: Outputs debug information.
       global: true
@@ -32,6 +34,10 @@ args:
       long: price
       aliases: [cost]
       takes_value: true
+  - file:
+    global: true
+    long: file
+    takes_value: true
   - payment:
       global: true
       long: payment
@@ -45,18 +51,20 @@ subcommands:
             aliases: [raf]
             about: A varient of YCH.
             args:
-              - tickets:
-                  aliases: [tkts]
-                  long: tickets
-                  takes_value: true
-                  required: true
+            - slots:
+                long: slots
+                takes_value: true
+            - tickets:
+                aliases: [tkts]
+                long: tickets
+                takes_value: true
       about: Your Character Here.
       args:
         - slot:
-            global: true
             long: slot
             takes_value: true
+            required: true
         - reference:
             long: ref
             takes_value: true
-            global: true
+            required: true

--- a/src/artm.yml
+++ b/src/artm.yml
@@ -6,23 +6,23 @@ args:
       long: cat
       takes_value: true
       possible_values: [ych, comm, req]
+      global: true
   - debug:
       help: Outputs debug information.
       aliases: [dbg]
       long: debug
       short: d
+      global: true
   - customer:
       long: cust
       takes_value: true
   - art:
-      global: true
       long: art
       takes_value: true
   - description:
       long: desc
       takes_value: true
   - contact:
-      global: true
       aliases: [cont]
       long: contact
       takes_value: true
@@ -40,3 +40,17 @@ args:
   - reference:
       long: ref
       takes_value: true
+
+subcommands:
+  - raffle:
+      about: YCH raffle
+      args:
+        - tickets:
+            aliases: [tkts]
+            long: tickets
+            takes_value: true
+            required: true
+        - slots:
+            long: slots
+            takes_value: true
+            required: true

--- a/src/cmds.rs
+++ b/src/cmds.rs
@@ -4,10 +4,13 @@
 
 // Argument names
 // =======================
+pub const YCH_CMD: &str = "ych";
+pub const RAFFLE_CMD: &str = "raffle";
+
 pub const COMM_FLAG: &str = "commission";
-pub const YCH_FLAG: &str = "ych";
 pub const REQ_FLAG: &str = "request";
 pub const DEBUG_FLAG: &str = "debug";
+pub const DATABASE_FLAG: &str = "database";
 
 pub const CLIENT_OPT: &str = "customer";
 pub const CONTACT_OPT: &str = "contact";
@@ -17,8 +20,6 @@ pub const PRICE_OPT: &str = "price";
 pub const SLOT_OPT: &str = "slot";
 pub const REF_OPT: &str = "reference";
 pub const DESC_OPT: &str = "description";
-
-pub const RAFFLE_CMD: &str = "raffle";
 // =======================
 
 // Messages

--- a/src/cmds.rs
+++ b/src/cmds.rs
@@ -6,18 +6,15 @@
 // =======================
 pub const RAFFLE_CMD: &str = "raffle";
 
-pub const COMM_FLAG: &str = "commission";
-pub const REQ_FLAG: &str = "request";
-pub const YCH_FLAG: &str = "ych";
 pub const DEBUG_FLAG: &str = "debug";
 pub const DATABASE_FLAG: &str = "database";
 
 pub const CAT_OPT: &str = "category";
-pub const CLIENT_OPT: &str = "customer";
+pub const CUST_NAME_OPT: &str = "customer";
 pub const TICKETS_OPT: &str = "tickets";
 pub const SLOTS_OPT: &str = "slots";
 pub const CONTACT_OPT: &str = "contact";
-pub const ART_OPT: &str = "art";
+pub const NAME_OPT: &str = "name";
 pub const PAYMENT_OPT: &str = "payment";
 pub const PRICE_OPT: &str = "price";
 pub const SLOT_OPT: &str = "slot";
@@ -30,3 +27,5 @@ pub const DESC_OPT: &str = "description";
 pub const ERROR_MSG: &str = "Application error";
 pub const CMD_NOT_FOUND_MSG: &str = "Command not found.";
 // =======================
+
+pub const EXIT_CODE: i32 = 1;

--- a/src/cmds.rs
+++ b/src/cmds.rs
@@ -14,6 +14,8 @@ pub const DATABASE_FLAG: &str = "database";
 
 pub const CAT_OPT: &str = "category";
 pub const CLIENT_OPT: &str = "customer";
+pub const TICKETS_OPT: &str = "tickets";
+pub const SLOTS_OPT: &str = "slots";
 pub const CONTACT_OPT: &str = "contact";
 pub const ART_OPT: &str = "art";
 pub const PAYMENT_OPT: &str = "payment";

--- a/src/cmds.rs
+++ b/src/cmds.rs
@@ -4,14 +4,15 @@
 
 // Argument names
 // =======================
-pub const YCH_CMD: &str = "ych";
 pub const RAFFLE_CMD: &str = "raffle";
 
 pub const COMM_FLAG: &str = "commission";
 pub const REQ_FLAG: &str = "request";
+pub const YCH_FLAG: &str = "ych";
 pub const DEBUG_FLAG: &str = "debug";
 pub const DATABASE_FLAG: &str = "database";
 
+pub const CAT_OPT: &str = "category";
 pub const CLIENT_OPT: &str = "customer";
 pub const CONTACT_OPT: &str = "contact";
 pub const ART_OPT: &str = "art";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
 // Copyright (c) Anthony Wilcox and contributors. All rights reserved.
 // Licensed under the GNU GPL v3 license. See LICENSE file in the project
 // root for full license information.
-pub mod models;
+pub mod art;
 pub mod cmds;
 
-use chrono::prelude::*;
-use rand::Rng;
 use clap::{crate_authors, crate_description, crate_version, load_yaml, App};
-use models::{Category, Customer, Art};
-use std::process;
+use art::{ych, comm, req, raffle};
 use cmds::*;
 
 fn main() {
@@ -20,49 +17,54 @@ fn main() {
         .version(crate_version!())
         .get_matches();
 
-    let cust = matches.value_of(CLIENT_OPT).unwrap();
-    let art = matches.value_of(ART_OPT).unwrap();
-    let reference = matches.value_of(REF_OPT).unwrap();
-    let slot = matches.value_of(SLOT_OPT).unwrap();
-    let price = matches.value_of(PRICE_OPT).unwrap();
-    let contact = matches.value_of(CONTACT_OPT).unwrap();
-    let payment = matches.value_of(PAYMENT_OPT).unwrap();
-    let category = matches.value_of(CAT_OPT).unwrap();
+    let debug = matches.is_present(DEBUG_FLAG);
+    let name = matches.value_of(NAME_OPT).unwrap();
 
-    if let Err(err) = Art::new()
-        .price(price)
-        .name(art)
-        .category(category)
-        .slot(slot)
-        .customer(Customer::new()
-            .name(cust)
-            .payment(payment)
-            .contact(contact)
-            .reference(reference))
-        .secure_id()
-        .write_file(matches.is_present(DEBUG_FLAG)) {
-        println!("{}: {}", ERROR_MSG, err);
-        process::exit(exit_code);
-    }
+    let mut cust_name = ""; //matches.value_of(CUST_NAME_OPT).unwrap();
+    let mut desc= ""; // matches.value_of(DESC_OPT).unwrap();
+    let mut contact = ""; // matches.value_of(CONTACT_OPT).unwrap();
+    let mut slot = "";
+    let mut payment = ""; // matches.value_of(PAYMENT_OPT).unwrap();
+    let mut price = ""; // matches.value_of(PRICE_OPT).unwrap();
+    let mut reference = "";
 
-    if let Some(raf) = matches.subcommand_matches(RAFFLE_CMD) {
-        let tickets = raf.value_of(TICKETS_OPT).unwrap();
-        let slots = raf.value_of(SLOTS_OPT).unwrap();
+    if !matches.is_present(RAFFLE_CMD) {
+        cust_name = matches.value_of(CUST_NAME_OPT).unwrap();
+        contact = matches.value_of(CONTACT_OPT).unwrap();
 
-        let choose_ticket = format!("{}", rand::thread_rng().gen_range(1, tickets.parse().unwrap()));
-        let choose_slot = format!("{}", rand::thread_rng().gen_range(1, slots.parse().unwrap()));
+        match matches.is_present(PAYMENT_OPT) {
+            true => {
+                payment = matches.value_of(PAYMENT_OPT).unwrap();
+                price = matches.value_of(PRICE_OPT).unwrap();
 
-        if let Err(err) = Art::new()
-            .price(price)
-            .name(art)
-            .category("ych")
-            .slot(choose_slot)
-            .ticket(choose_ticket)
-            .secure_id()
-            .write_file(matches.is_present(DEBUG_FLAG)) {
-            println!("{}: {}", ERROR_MSG, err);
-            process::exit(exit_code);
+                match matches.is_present(SLOT_OPT) || matches.is_present(REF_OPT) {
+                    true => {
+                        slot = matches.value_of(SLOT_OPT).unwrap();
+                        reference = matches.value_of(REF_OPT).unwrap();
+
+                        ych(name, price, slot, reference, cust_name, payment, contact, debug);
+                    }
+                    false => {
+                        desc = matches.value_of(DESC_OPT).unwrap();
+
+                        comm(name, price, desc, cust_name,payment, contact, debug);
+                    }
+                }
+            }
+            false => {
+                desc = matches.value_of(DESC_OPT).unwrap();
+
+                req(name, desc, cust_name, contact, debug);
+            }
         }
+    }
+    else {
+        /*
+        let slots = matches.value_of(SLOTS_OPT).unwrap();
+        let tickets = matches.value_of(TICKETS_OPT).unwrap();
 
+        raffle(name, tickets.parse().unwrap(), slots.parse().unwrap(), debug);
+        */
+        unimplemented!();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,12 @@ fn main() {
     let debug = matches.is_present(DEBUG_FLAG);
     let name = matches.value_of(NAME_OPT).unwrap();
 
-    let mut cust_name = ""; //matches.value_of(CUST_NAME_OPT).unwrap();
-    let mut desc= ""; // matches.value_of(DESC_OPT).unwrap();
-    let mut contact = ""; // matches.value_of(CONTACT_OPT).unwrap();
+    let mut cust_name = "";
+    let mut desc= "";
+    let mut contact = "";
     let mut slot = "";
-    let mut payment = ""; // matches.value_of(PAYMENT_OPT).unwrap();
-    let mut price = ""; // matches.value_of(PRICE_OPT).unwrap();
+    let mut payment = "";
+    let mut price = "";
     let mut reference = "";
 
     if !matches.is_present(RAFFLE_CMD) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,9 @@ pub mod cmds;
 
 use chrono::prelude::*;
 use clap::{crate_authors, crate_description, crate_version, load_yaml, App};
-use models::{Commission, Request, YCH};
+use models::{Category, Customer, Art};
 use std::process;
 use cmds::*;
-use uuid::Uuid;
 
 fn main() {
     let exit_code = 1;
@@ -20,121 +19,28 @@ fn main() {
         .version(crate_version!())
         .get_matches();
 
-    if let Some(ych) = matches.subcommand_matches(YCH_CMD) {
-        let client = ych.value_of(CLIENT_OPT).unwrap();
-        let art = ych.value_of(ART_OPT).unwrap();
-        let reference = ych.value_of(REF_OPT).unwrap();
-        let slot = ych.value_of(SLOT_OPT).unwrap();
-        let price = ych.value_of(PRICE_OPT).unwrap();
-        let contact = ych.value_of(CONTACT_OPT).unwrap();
-        let payment = ych.value_of(PAYMENT_OPT).unwrap();
+    let cust = matches.value_of(CLIENT_OPT).unwrap();
+    let art = matches.value_of(ART_OPT).unwrap();
+    let reference = matches.value_of(REF_OPT).unwrap();
+    let slot = matches.value_of(SLOT_OPT).unwrap();
+    let price = matches.value_of(PRICE_OPT).unwrap();
+    let contact = matches.value_of(CONTACT_OPT).unwrap();
+    let payment = matches.value_of(PAYMENT_OPT).unwrap();
+    let category = matches.value_of(CAT_OPT).unwrap();
 
-        if ych.is_present(DEBUG_FLAG) {
-            if let Err(err) = YCH::print_ych(YCH {
-                id: Uuid::new_v4().to_string(),
-                date: Local::now(),
-                art: art.to_owned(),
-                customer: client.to_owned(),
-                reference: reference.to_owned(),
-                price: price.to_owned(),
-                slot: slot.to_owned(),
-                contact: contact.to_owned(),
-                payment: payment.to_owned(),
-            }) {
-                println!("{}: {}", ERROR_MSG, err);
-                process::exit(exit_code);
-            }
-        } else {
-            if let Err(err) = YCH::write_ych(YCH {
-                id: Uuid::new_v4().to_string(),
-                date: Local::now(),
-                art: art.to_owned(),
-                reference: reference.to_owned(),
-                customer: client.to_owned(),
-                price: price.to_owned(),
-                slot: slot.to_owned(),
-                contact: contact.to_owned(),
-                payment: payment.to_owned(),
-            }) {
-                println!("{}: {}", ERROR_MSG, err);
-                process::exit(exit_code);
-            }
-        }
-
-        if let Some(_raf) = matches.subcommand_matches(RAFFLE_CMD) {
-            unimplemented!();
-        }
-    }
-
-    if matches.is_present(COMM_FLAG) {
-        let client = matches.value_of(CLIENT_OPT).unwrap();
-        let art = matches.value_of(ART_OPT).unwrap();
-        let cost = matches.value_of(PRICE_OPT).unwrap();
-        let contact = matches.value_of(CONTACT_OPT).unwrap();
-        let payment = matches.value_of(PAYMENT_OPT).unwrap();
-        let description = matches.value_of(DESC_OPT).unwrap();
-
-        if matches.is_present(DEBUG_FLAG) {
-            if let Err(err) = Commission::print_comm(Commission {
-                id: Uuid::new_v4().to_string(),
-                date: Local::now(),
-                customer: client.to_owned(),
-                art: art.to_owned(),
-                price: cost.to_owned(),
-                contact: contact.to_owned(),
-                payment: payment.to_owned(),
-                description: description.to_owned(),
-            }) {
-                println!("{}: {}", ERROR_MSG, err);
-                process::exit(exit_code);
-            }
-        } else {
-            if let Err(err) = Commission::write_comm(Commission {
-                id: Uuid::new_v4().to_string(),
-                date: Local::now(),
-                customer: client.to_owned(),
-                art: art.to_owned(),
-                price: cost.to_owned(),
-                contact: contact.to_owned(),
-                payment: payment.to_owned(),
-                description: description.to_owned(),
-            }) {
-                println!("{}: {}", ERROR_MSG, err);
-                process::exit(exit_code);
-            }
-        }
-    }
-
-    if matches.is_present(REQ_FLAG) {
-        let client = matches.value_of(CLIENT_OPT).unwrap();
-        let art = matches.value_of(ART_OPT).unwrap();
-        let contact = matches.value_of(CONTACT_OPT).unwrap();
-        let description = matches.value_of(DESC_OPT).unwrap();
-
-        if matches.is_present(DEBUG_FLAG) {
-            if let Err(err) = Request::print_req(Request {
-                id: Uuid::new_v4().to_string(),
-                date: Local::now(),
-                art: art.to_owned(),
-                customer: client.to_owned(),
-                contact: contact.to_owned(),
-                description: description.to_owned(),
-            }) {
-                println!("{}: {}", ERROR_MSG, err);
-                process::exit(exit_code);
-            }
-        } else {
-            if let Err(err) = Request::write_req(Request {
-                id: Uuid::new_v4().to_string(),
-                date: Local::now(),
-                art: art.to_owned(),
-                customer: client.to_owned(),
-                contact: contact.to_owned(),
-                description: description.to_owned(),
-            }) {
-                println!("{}: {}", ERROR_MSG, err);
-                process::exit(exit_code);
-            }
-        }
+    if let Err(err) = Art::new()
+        .price(price)
+        .name(art)
+        .category(category)
+        .slot(slot)
+        .customer(Customer::new()
+            .name(cust)
+            .payment(payment)
+            .contact(contact)
+            .reference(reference))
+        .secure_id()
+        .write_file(matches.is_present(DEBUG_FLAG)) {
+        println!("{}: {}", ERROR_MSG, err);
+        process::exit(exit_code);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,25 @@ pub mod art;
 pub mod cmds;
 
 use clap::{crate_authors, crate_description, crate_version, load_yaml, App};
-use art::{ych, comm, req, raffle};
+use art::{ych, comm, req};
+use simplelog::*;
+use std::fs::File;
 use cmds::*;
 
 fn main() {
-    let exit_code = 1;
+    let log_file = "artm.log";
+
+    CombinedLogger::init(
+        vec![
+            TermLogger::new(LevelFilter::Warn,
+                            Config::default()).unwrap(),
+            WriteLogger::new(LevelFilter::Info,
+                             Config::default(),
+                             File::create(log_file).unwrap()),
+
+        ]
+    ).unwrap();
+
     let yaml = load_yaml!("artm.yml");
     let matches = App::from_yaml(yaml)
         .author(crate_authors!())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ pub mod models;
 pub mod cmds;
 
 use chrono::prelude::*;
+use rand::Rng;
 use clap::{crate_authors, crate_description, crate_version, load_yaml, App};
 use models::{Category, Customer, Art};
 use std::process;
@@ -42,5 +43,26 @@ fn main() {
         .write_file(matches.is_present(DEBUG_FLAG)) {
         println!("{}: {}", ERROR_MSG, err);
         process::exit(exit_code);
+    }
+
+    if let Some(raf) = matches.subcommand_matches(RAFFLE_CMD) {
+        let tickets = raf.value_of(TICKETS_OPT).unwrap();
+        let slots = raf.value_of(SLOTS_OPT).unwrap();
+
+        let choose_ticket = format!("{}", rand::thread_rng().gen_range(1, tickets.parse().unwrap()));
+        let choose_slot = format!("{}", rand::thread_rng().gen_range(1, slots.parse().unwrap()));
+
+        if let Err(err) = Art::new()
+            .price(price)
+            .name(art)
+            .category("ych")
+            .slot(choose_slot)
+            .ticket(choose_ticket)
+            .secure_id()
+            .write_file(matches.is_present(DEBUG_FLAG)) {
+            println!("{}: {}", ERROR_MSG, err);
+            process::exit(exit_code);
+        }
+
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,27 +2,25 @@
 // Licensed under the GNU GPL v3 license. See LICENSE file in the project
 // root for full license information.
 pub mod models;
-pub mod tstr;
+pub mod cmds;
 
-use clap::{App, crate_version, crate_authors,
-           crate_description, load_yaml};
-use std::process;
-use uuid::Uuid;
-use models::{YCH, Commission, Request};
 use chrono::prelude::*;
-use tstr::*;
+use clap::{crate_authors, crate_description, crate_version, load_yaml, App};
+use models::{Commission, Request, YCH};
+use std::process;
+use cmds::*;
+use uuid::Uuid;
 
 fn main() {
     let exit_code = 1;
-    let yaml = load_yaml!("cli.yml");
+    let yaml = load_yaml!("artm.yml");
     let matches = App::from_yaml(yaml)
         .author(crate_authors!())
         .about(crate_description!())
         .version(crate_version!())
         .get_matches();
 
-    if let Some(ych) = matches.subcommand_matches(YCH_FLAG)
-    {
+    if let Some(ych) = matches.subcommand_matches(YCH_CMD) {
         let client = ych.value_of(CLIENT_OPT).unwrap();
         let art = ych.value_of(ART_OPT).unwrap();
         let reference = ych.value_of(REF_OPT).unwrap();
@@ -31,15 +29,28 @@ fn main() {
         let contact = ych.value_of(CONTACT_OPT).unwrap();
         let payment = ych.value_of(PAYMENT_OPT).unwrap();
 
-        if ych.is_present(DEBUG_FLAG)
-        {
+        if ych.is_present(DEBUG_FLAG) {
             if let Err(err) = YCH::print_ych(YCH {
-                id: Uuid::new_v4()
-                    .to_string(),
+                id: Uuid::new_v4().to_string(),
                 date: Local::now(),
                 art: art.to_owned(),
                 customer: client.to_owned(),
                 reference: reference.to_owned(),
+                price: price.to_owned(),
+                slot: slot.to_owned(),
+                contact: contact.to_owned(),
+                payment: payment.to_owned(),
+            }) {
+                println!("{}: {}", ERROR_MSG, err);
+                process::exit(exit_code);
+            }
+        } else {
+            if let Err(err) = YCH::write_ych(YCH {
+                id: Uuid::new_v4().to_string(),
+                date: Local::now(),
+                art: art.to_owned(),
+                reference: reference.to_owned(),
+                customer: client.to_owned(),
                 price: price.to_owned(),
                 slot: slot.to_owned(),
                 contact: contact.to_owned(),
@@ -49,28 +60,13 @@ fn main() {
                 process::exit(exit_code);
             }
         }
-        else
-        {
-            if let Err(err) = YCH::write_ych(YCH {
-                id: Uuid::new_v4()
-                    .to_string(),
-                date: Local::now(),
-                art: art.to_owned(),
-                reference: reference.to_owned(),
-                customer: client.to_owned(),
-                price: price.to_owned(),
-                slot: slot.to_owned(),
-                contact: contact.to_owned(),
-                payment: payment.to_owned(),
-            }) {
-                println!("{}: {}", ERROR_MSG, err);
-                process::exit(exit_code);
-            }
+
+        if let Some(_raf) = matches.subcommand_matches(RAFFLE_CMD) {
+            unimplemented!();
         }
     }
 
-    if matches.is_present(COMM_FLAG)
-    {
+    if matches.is_present(COMM_FLAG) {
         let client = matches.value_of(CLIENT_OPT).unwrap();
         let art = matches.value_of(ART_OPT).unwrap();
         let cost = matches.value_of(PRICE_OPT).unwrap();
@@ -78,11 +74,9 @@ fn main() {
         let payment = matches.value_of(PAYMENT_OPT).unwrap();
         let description = matches.value_of(DESC_OPT).unwrap();
 
-        if matches.is_present(DEBUG_FLAG)
-        {
+        if matches.is_present(DEBUG_FLAG) {
             if let Err(err) = Commission::print_comm(Commission {
-                id: Uuid::new_v4()
-                    .to_string(),
+                id: Uuid::new_v4().to_string(),
                 date: Local::now(),
                 customer: client.to_owned(),
                 art: art.to_owned(),
@@ -94,12 +88,9 @@ fn main() {
                 println!("{}: {}", ERROR_MSG, err);
                 process::exit(exit_code);
             }
-        }
-        else
-        {
+        } else {
             if let Err(err) = Commission::write_comm(Commission {
-                id: Uuid::new_v4()
-                    .to_string(),
+                id: Uuid::new_v4().to_string(),
                 date: Local::now(),
                 customer: client.to_owned(),
                 art: art.to_owned(),
@@ -114,18 +105,15 @@ fn main() {
         }
     }
 
-    if matches.is_present(REQ_FLAG)
-    {
+    if matches.is_present(REQ_FLAG) {
         let client = matches.value_of(CLIENT_OPT).unwrap();
         let art = matches.value_of(ART_OPT).unwrap();
         let contact = matches.value_of(CONTACT_OPT).unwrap();
         let description = matches.value_of(DESC_OPT).unwrap();
 
-        if matches.is_present(DEBUG_FLAG)
-        {
+        if matches.is_present(DEBUG_FLAG) {
             if let Err(err) = Request::print_req(Request {
-                id: Uuid::new_v4()
-                    .to_string(),
+                id: Uuid::new_v4().to_string(),
                 date: Local::now(),
                 art: art.to_owned(),
                 customer: client.to_owned(),
@@ -135,12 +123,9 @@ fn main() {
                 println!("{}: {}", ERROR_MSG, err);
                 process::exit(exit_code);
             }
-        }
-        else
-        {
+        } else {
             if let Err(err) = Request::write_req(Request {
-                id: Uuid::new_v4()
-                    .to_string(),
+                id: Uuid::new_v4().to_string(),
                 date: Local::now(),
                 art: art.to_owned(),
                 customer: client.to_owned(),
@@ -151,10 +136,5 @@ fn main() {
                 process::exit(exit_code);
             }
         }
-    }
-
-    if let Some(raf) = matches.subcommand_matches(RAFFLE_CMD)
-    {
-        unimplemented!();
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,15 +2,16 @@
 // Licensed under the GNU GPL v3 license. See LICENSE file in the project
 // root for full license information.
 use chrono::prelude::*;
+use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
 use std::fs::OpenOptions;
 use std::io::Write;
+use core::fmt::Debug;
 
-const AMY_EXT: &str = "amy";
-const AMC_EXT: &str = "amc";
-const AMR_EXT: &str = "amr";
+const ARTM_EXT: &str = "artm";
 
+#[derive(Serialize, Deserialize, Debug)]
 pub enum Category {
     YCH,
     Commission,
@@ -18,224 +19,179 @@ pub enum Category {
     Unknown
 }
 
-#[obsolete]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct YCH {
-    pub id: String,
-    /// Uses the local time
-    pub date: DateTime<Local>,
-    pub customer: String,
-    pub reference: String,
-    /// The YCH
-    pub art: String,
-    /// Slot the customer won in the auction
-    pub slot: String,
-    pub contact: String,
-    pub price: String,
-    /// Payment information (paypal, crypto, ect)
-    pub payment: String,
-}
-
-#[obsolete]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Commission {
-    pub id: String,
-    /// Uses the local time
-    pub date: DateTime<Local>,
-    pub art: String,
-    pub customer: String,
-    pub contact: String,
-    pub price: String,
-    /// Payment information (paypal, crypto, ect)
-    pub payment: String,
-    pub description: String,
-}
-
-#[obsolete]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Request {
-    pub id: String,
-    /// Uses the local time
-    pub date: DateTime<Local>,
-    pub customer: String,
-    pub contact: String,
-    pub art: String,
-    pub description: String,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Customer {
     pub name: String,
     pub contact: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
     /// Payment information (paypal, crypto, ect)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payment: Option<String>,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Art {
     pub id: String,
-    pub category: Option<Category>,
     /// Use local time
     pub date: DateTime<Local>,
-    pub customer: Option<Customer>,
-    pub ticket: Option<Raffle>,
+    pub version: String,
+    pub name: String,
+    pub category: Option<Category>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ticket: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub slot: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub price: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub customer: Option<Customer>,
 }
 
 impl Default for Category {
     fn default() -> Self { Category::Unknown }
 }
 
+impl Customer {
+    pub fn new() -> Customer {
+        Customer {
+            name: "".to_string(),
+            contact: "".to_string(),
+            reference: None,
+            payment: None
+        }
+    }
+
+    pub fn name<S: Into<String>>(mut self, name: S)
+        -> Customer where S: Into<String> {
+        self.name = name.into();
+        self
+    }
+
+    pub fn contact<S: Into<String>>(mut self, cont: S)
+        -> Customer where S: Into<String> {
+        self.contact = cont.into();
+        self
+    }
+
+    pub fn reference<S: Into<String>>(mut self, reference: S)
+                                    -> Customer where S: Into<String> {
+        self.reference = Some(reference.into());
+        self
+    }
+
+    pub fn payment<S: Into<String>>(mut self, pay: S)
+        -> Customer where S: Into<String> {
+        self.payment = Some(pay.into());
+        self
+    }
+}
 
 impl Art {
-    pub fn customer<S: Into<String>>(cust: S)
-        -> String where S: Into<String> {
-        cust.into()
-    }
 
-    pub fn contact<S: Into<String>>(cont: S)
-        -> String where S: Into<String> {
-        cont.into()
-    }
-
-    pub fn art<S: Into<String>>(art: S)
-        -> String where S: Into<String> {
-        art.into()
-    }
-
-    pub fn price<S: Into<String>>(price: S)
-        -> String where S: Into<String> {
-        price.into()
-    }
-
-    pub fn description<S: Into<String>>(desc: S)
-        -> String where S: Into<String> {
-        desc.into()
-    }
-}
-
-impl YCH {
-    pub fn write_ych(ych: YCH) -> Result<()> {
-        let new_ych = YCH { id: ych.id, date: ych.date, customer: ych.customer,
-            art: ych.art, slot: ych.slot, contact: ych.contact,
-            payment: ych.payment, price: ych.price, reference: ych.reference
-        };
-
-        let json_string = serde_json::to_string_pretty(&new_ych)?;
-        let order_string = new_ych.art.to_owned().to_lowercase();
-        let slot_string = new_ych.slot.to_owned().to_lowercase();
-        let client_string = new_ych.customer.to_owned().to_lowercase();
-        let file_name = format!("{} - {} - {}.{}",
-                                order_string, slot_string, client_string, AMY_EXT);
-        let mut file = OpenOptions::new().write(true)
-            .create_new(true)
-            .open(file_name)
-            .expect("Could not open file.");
-
-        if let Err(err) = writeln!(file, "{}", format!("{}", json_string)) {
-            eprintln!("Couldn't write to file. {}", err);
+    pub fn new() -> Art {
+        Art {
+            id: Uuid::new_v4().to_hyphenated().to_string(),
+            date: Local::now(),
+            version: "0.1".to_string(),
+            name: "".to_string(),
+            category: Some(Category::default()),
+            customer: None,
+            ticket: None,
+            slot: None,
+            price: None,
+            description: None
         }
-
-        Ok(())
     }
 
-    pub fn print_ych(ych: YCH) -> Result<()> {
+    pub fn secure_id(mut self) -> Art {
+        let hash = Uuid::new_v5(&Uuid::NAMESPACE_OID,format!("{}+artm", self.name).as_bytes())
+            .to_hyphenated().to_string();
 
-        let new_ych = YCH { id: ych.id, date: ych.date, customer: ych.customer,
-            art: ych.art, slot: ych.slot, contact: ych.contact,
-            payment: ych.payment, price: ych.price, reference: ych.reference
-        };
+        self.id = hash;
 
-        let json_string = serde_json::to_string_pretty(&new_ych)?;
-
-        println!("{}", json_string);
-
-        Ok(())
+        self
     }
-}
 
-impl Commission {
-    pub fn write_comm(comm: Commission) -> Result<()> {
+    pub fn customer(mut self, cust: Customer) -> Art {
+        self.customer = Some(cust.into());
+        self
+    }
 
-        let new_comm = Commission {
-            id: comm.id, date: comm.date, customer: comm.customer,
-            contact: comm.contact, payment: comm.payment,
-            price: comm.price, description: comm.description,
-            art: comm.art,
-        };
+    pub fn name<S: Into<String>>(mut self, name: S)
+        -> Art where S: Into<String> {
+        self.name = name.into();
+        self
+    }
 
-        let json_string = serde_json::to_string_pretty(&new_comm)?;
-        let order_string = new_comm.art.to_string().to_lowercase();
-        let client_string = new_comm.customer.to_string().to_lowercase();
-        let file_name = format!("{} - {}.{}", order_string, client_string, AMC_EXT);
-        let mut file = OpenOptions::new().write(true)
-            .create_new(true)
-            .open(file_name)
-            .expect("Could not open file.");
+    pub fn price<S: Into<String>>(mut self, price: S)
+        -> Art where S: Into<String> {
+        self.price = Some(price.into());
+        self
+    }
 
-        if let Err(err) = writeln!(file, "{}", format!("{}", json_string)) {
-            eprintln!("Couldn't write to file. {}", err);
+    pub fn description<S: Into<String>>(mut self, desc: S)
+        -> Art where S: Into<String> {
+        self.description = Some(desc.into());
+        self
+    }
+
+    pub fn slot<S: Into<String>>(mut self, slot: S)
+                                        -> Art where S: Into<String> {
+        self.slot = Some(slot.into());
+        self
+    }
+
+    pub fn reference<S: Into<String>>(mut self, desc: S)
+                                        -> Art where S: Into<String> {
+        self.description = Some(desc.into());
+        self
+    }
+
+    pub fn category(mut self, cat: &str) -> Art {
+        match cat {
+            "ych" => self.category = Some(Category::YCH),
+            "comm" => self.category = Some(Category::Commission),
+            "req" => self.category = Some(Category::Request),
+            _ => self.category = Some(Category::default()),
         }
-
-        Ok(())
+        self
     }
 
+    pub fn write_file(&self, debug: bool) -> Result<()> {
+        let json_string = serde_json::to_string_pretty(self)?;
 
-    pub fn print_comm(comm: Commission) -> Result<()> {
+        match debug {
+            true => println!("{}", json_string),
+            false => {
+                let cat = &self.category;
+                let slot = self.slot.to_owned().unwrap();
+                let name = self.name.to_owned();
+                let mut file_name = String::new();
 
-        let new_comm = Commission {
-            id: comm.id, date: comm.date, customer: comm.customer,
-            contact: comm.contact, payment: comm.payment,
-            price: comm.price, description: comm.description,
-            art: comm.art,
-        };
+                match cat {
+                    Some(Category::YCH) => {
+                        file_name = format!("{} - slot {}.{}",
+                                                name, slot, ARTM_EXT);
+                    }
+                    _ => {
+                        file_name = format!("{}.{}",
+                                            name, ARTM_EXT);
+                    }
+                }
 
-        let json_string = serde_json::to_string_pretty(&new_comm)?;
+                let mut file = OpenOptions::new().write(true)
+                    .create_new(true)
+                    .open(file_name)
+                    .expect("Could not open file.");
 
-        println!("{}", json_string);
-
-        Ok(())
-    }
-}
-
-impl Request {
-    pub fn write_req(req: Request) -> Result<()> {
-
-        let new_req = Request {
-            id: req.id, date: req.date, contact: req.contact,
-            customer: req.customer, description: req.description,
-            art: req.art
-        };
-
-        let json_string = serde_json::to_string_pretty(&new_req)?;
-        let name_string = new_req.art.to_string().to_lowercase();
-        let client_string = new_req.customer.to_string().to_lowercase();
-        let file_name = format!("{} - {}.{}", name_string, client_string, AMR_EXT);
-        let mut file = OpenOptions::new().write(true)
-            .create_new(true)
-            .open(file_name)
-            .expect("Could not open file.");
-
-        if let Err(err) = writeln!(file, "{}", format!("{}", json_string)) {
-            eprintln!("Couldn't write to file. {}", err);
+                if let Err(err) = writeln!(file, "{}", format!("{}", json_string)) {
+                    eprintln!("Could not write to file. {}", err);
+                }
+            }
         }
-
-        Ok(())
-    }
-
-    pub fn print_req(req: Request) -> Result<()> {
-
-        let new_req = Request {
-            id: req.id, date: req.date, contact: req.contact,
-            customer: req.customer, description: req.description,
-            art: req.art
-        };
-
-        let json_string = serde_json::to_string_pretty(&new_req)?;
-
-        println!("{}", json_string);
 
         Ok(())
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,16 +1,24 @@
 // Copyright (c) Anthony Wilcox and contributors. All rights reserved.
 // Licensed under the GNU GPL v3 license. See LICENSE file in the project
 // root for full license information.
-use std::io::Write;
-use std::fs::OpenOptions;
+use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
-use chrono::prelude::*;
+use std::fs::OpenOptions;
+use std::io::Write;
 
 const AMY_EXT: &str = "amy";
 const AMC_EXT: &str = "amc";
 const AMR_EXT: &str = "amr";
 
+pub enum Category {
+    YCH,
+    Commission,
+    Request,
+    Unknown
+}
+
+#[obsolete]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct YCH {
     pub id: String,
@@ -28,6 +36,7 @@ pub struct YCH {
     pub payment: String,
 }
 
+#[obsolete]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Commission {
     pub id: String,
@@ -42,6 +51,7 @@ pub struct Commission {
     pub description: String,
 }
 
+#[obsolete]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Request {
     pub id: String,
@@ -53,6 +63,58 @@ pub struct Request {
     pub description: String,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Customer {
+    pub name: String,
+    pub contact: String,
+    /// Payment information (paypal, crypto, ect)
+    pub payment: Option<String>,
+}
+
+#[derive(Default, Serialize, Deserialize, Debug)]
+pub struct Art {
+    pub id: String,
+    pub category: Option<Category>,
+    /// Use local time
+    pub date: DateTime<Local>,
+    pub customer: Option<Customer>,
+    pub ticket: Option<Raffle>,
+    pub slot: Option<String>,
+    pub price: Option<String>,
+    pub description: Option<String>,
+}
+
+impl Default for Category {
+    fn default() -> Self { Category::Unknown }
+}
+
+
+impl Art {
+    pub fn customer<S: Into<String>>(cust: S)
+        -> String where S: Into<String> {
+        cust.into()
+    }
+
+    pub fn contact<S: Into<String>>(cont: S)
+        -> String where S: Into<String> {
+        cont.into()
+    }
+
+    pub fn art<S: Into<String>>(art: S)
+        -> String where S: Into<String> {
+        art.into()
+    }
+
+    pub fn price<S: Into<String>>(price: S)
+        -> String where S: Into<String> {
+        price.into()
+    }
+
+    pub fn description<S: Into<String>>(desc: S)
+        -> String where S: Into<String> {
+        desc.into()
+    }
+}
 
 impl YCH {
     pub fn write_ych(ych: YCH) -> Result<()> {

--- a/src/models.rs
+++ b/src/models.rs
@@ -106,6 +106,12 @@ impl Art {
         }
     }
 
+    pub fn ticket<S: Into<String>>(mut self, ticket: S) -> Art where S: Into<String> {
+        self.ticket = Some(ticket.into());
+
+        self
+    }
+
     pub fn secure_id(mut self) -> Art {
         let hash = Uuid::new_v5(&Uuid::NAMESPACE_OID,format!("{}+artm", self.name).as_bytes())
             .to_hyphenated().to_string();


### PR DESCRIPTION
The current ``.artm[ycr]`` formats has been redone as ``.art[ycr]``. The older format was based on three independent implementations that all did very similar things but lacked room for change. This worked as a proof-as-concept but left no room to grow. This new format merges all three by making every field optional and won't show up, if left empty, with the exception of name, version, date and Id.

```json
{
  "id": "",
  "version": "",
  "name": "",
  "price": "",
  "ticket": "",
  "slot": "",
  "description": "",
  "reference": "",
  "customer": {
    "name": "",
    "contact": "",
    "payment": ""
  }
}
```
And so the previous YCH example found in the usage page becomes...
```json
{
  "id": "c152c08a-1250-45c1-a51d-a38354804933",
  "date": "2019-04-05T13:53:43.670815600-04:00",
  "version": "0.1",
  "name": "Synthesize",
  "category": "YCH",
  "slot": "4",
  "price": "$25",
  "reference": "https://www.furaffinity.net/view/20700210/",
  "customer": {
    "name": "Bessie Hettinger",
    "contact": "Jack.Torphy75",
    "payment": "31VLNZXfcpoA68wPRuWSdrmT3jv5k"
  }
}
```
We're able to create as many variations of this format as we want using the [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern), this method is common in a lot of Rust libraries and frameworks. This takes care of a lot of the heavy lifting and allows for any number of combination to exist.

```rust
// Example
    if let Err(err) = Art::new()
        .price(price)
        .name(name)
        .category(Category::YCH)
        .slot(slot)
        .reference(reference)
        .customer(Customer::new()
            .name(cust_name)
            .payment(pay)
            .contact(cont))
        .secure_id()
        .debug(debug)
        .write_file() {
        println!("{}: {}", ERROR_MSG, err);
        process::exit(EXIT_CODE);
    }
```